### PR TITLE
make variables public and remove get functions

### DIFF
--- a/NetUtils.podspec.json
+++ b/NetUtils.podspec.json
@@ -7,7 +7,8 @@
         "type": "The Unlicense <http://unlicense.org>"
     },
     "source": {
-        "git": "https://github.com/svdo/swift-netutils.git"
+        "git": "https://github.com/svdo/swift-netutils.git",
+        "tag": "1.3.2"
     },
     "authors": "Stefan van den Oord",
     "platforms": {

--- a/NetUtils.podspec.json
+++ b/NetUtils.podspec.json
@@ -1,6 +1,6 @@
 {
     "name": "NetUtils",
-    "version": "1.4.0",
+    "version": "1.3.2",
     "summary": "Swift library that simplifies getting information about your network interfaces and their properties, both for iOS and OS X.",
     "homepage": "https://github.com/svdo/swift-netutils",
     "license": {
@@ -8,7 +8,7 @@
     },
     "source": {
         "git": "https://github.com/svdo/swift-netutils.git",
-        "tag": "1.4.0"
+        "tag": "1.3.2"
     },
     "authors": "Stefan van den Oord",
     "platforms": {

--- a/NetUtils.podspec.json
+++ b/NetUtils.podspec.json
@@ -7,8 +7,7 @@
         "type": "The Unlicense <http://unlicense.org>"
     },
     "source": {
-        "git": "https://github.com/svdo/swift-netutils.git",
-        "tag": "1.3.2"
+        "git": "https://github.com/svdo/swift-netutils.git"
     },
     "authors": "Stefan van den Oord",
     "platforms": {

--- a/NetUtils.podspec.json
+++ b/NetUtils.podspec.json
@@ -1,6 +1,6 @@
 {
     "name": "NetUtils",
-    "version": "1.3.2",
+    "version": "1.4.0",
     "summary": "Swift library that simplifies getting information about your network interfaces and their properties, both for iOS and OS X.",
     "homepage": "https://github.com/svdo/swift-netutils",
     "license": {
@@ -8,7 +8,7 @@
     },
     "source": {
         "git": "https://github.com/svdo/swift-netutils.git",
-        "tag": "1.3.2"
+        "tag": "1.4.0"
     },
     "authors": "Stefan van den Oord",
     "platforms": {

--- a/NetUtils/Interface.swift
+++ b/NetUtils/Interface.swift
@@ -121,12 +121,8 @@ public class Interface : CustomStringConvertible, CustomDebugStringConvertible {
         let s = String.fromCString(conversion)
         return s
     }
-
-    public func getName() -> String { return name }
-    public func getFamily() -> Family { return family }
-
-    public func getAddress() -> String? { return address }
-    public func getAddressBytes() -> [UInt8]? {
+    
+    public var addressBytes: [UInt8]? {
         guard let addr = address else { return nil }
         
         let af:Int32
@@ -145,32 +141,29 @@ public class Interface : CustomStringConvertible, CustomDebugStringConvertible {
         let result = inet_pton(af, addr, &bytes)
         return ( result == 1 ) ? bytes : nil
     }
-    public func getNetmask() -> String? { return netmask }
-    public func getBroadcastAddress() -> String? { return broadcastAddress }
-    public func isRunning() -> Bool { return running }
-    public func isUp() -> Bool { return up }
-    public func isLoopback() -> Bool { return loopback }
-    public func supportsMulticast() -> Bool { return multicastSupported }
+    public var isRunning: Bool { return running }
+    public var isUp: Bool { return up }
+    public var isLoopback: Bool { return loopback }
+    public var supportsMulticast: Bool { return multicastSupported }
 
-    private let name : String
-    private let family : Family
-    private let address : String?
-    private let netmask : String?
-    private let broadcastAddress : String?
+    public let name : String
+    public let family : Family
+    public let address : String?
+    public let netmask : String?
+    public let broadcastAddress : String?
     private let running : Bool
     private let up : Bool
     private let loopback : Bool
     private let multicastSupported : Bool
     
-    public var description: String { get { return getName() } }
-    public var debugDescription: String { get {
-        var s = "Interface name:\(getName()) family:\(getFamily())"
-        if let ip = getAddress() {
+    public var description: String { return name }
+    public var debugDescription: String {
+        var s = "Interface name:\(name) family:\(family)"
+        if let ip = address {
             s += " ip:\(ip)"
         }
-        s += isUp() ? " (up)" : " (down)"
-        s += isRunning() ? " (running)" : "(not running)"
+        s += isUp ? " (up)" : " (down)"
+        s += isRunning ? " (running)" : "(not running)"
         return s
-        } }
-
+    }
 }

--- a/NetUtils/Interface.swift
+++ b/NetUtils/Interface.swift
@@ -37,11 +37,6 @@ public class Interface : CustomStringConvertible, CustomDebugStringConvertible {
         return interfaces
     }
     
-    public static var ipAddress: String? {
-        
-        return allInterfaces().filter({$0.name == "en0" && $0.family == .ipv4 }).last?.address
-    }
-    
     /**
      *  Returns a new Interface instance that does not represent a real network interface, but can be used for (unit) testing.
      */

--- a/NetUtils/Interface.swift
+++ b/NetUtils/Interface.swift
@@ -19,13 +19,17 @@ public class Interface : CustomStringConvertible, CustomDebugStringConvertible {
     public static func allInterfaces() -> [Interface] {
         var interfaces : [Interface] = []
         
-        var ifaddrsPtr = UnsafeMutablePointer<ifaddrs>()
+        var ifaddrsPtr = UnsafeMutablePointer<ifaddrs>(nil)
         if getifaddrs(&ifaddrsPtr) == 0 {
-            for (var ifaddrPtr = ifaddrsPtr; ifaddrPtr != nil; ifaddrPtr = ifaddrPtr.memory.ifa_next) {
+            
+            var ifaddrPtr = ifaddrsPtr
+            
+            while ifaddrPtr != nil {
                 let addr = ifaddrPtr.memory.ifa_addr.memory
                 if addr.sa_family == UInt8(AF_INET) || addr.sa_family == UInt8(AF_INET6) {
                     interfaces.append(Interface(data: ifaddrPtr.memory))
                 }
+                ifaddrPtr = ifaddrPtr.memory.ifa_next
             }
             freeifaddrs(ifaddrsPtr)
         }

--- a/NetUtils/Interface.swift
+++ b/NetUtils/Interface.swift
@@ -37,6 +37,11 @@ public class Interface : CustomStringConvertible, CustomDebugStringConvertible {
         return interfaces
     }
     
+    public static var ipAddress: String? {
+        
+        return allInterfaces().filter({$0.name == "en0" && $0.family == .ipv4 }).last?.address
+    }
+    
     /**
      *  Returns a new Interface instance that does not represent a real network interface, but can be used for (unit) testing.
      */

--- a/NetUtilsTests/NetUtilsTests.swift
+++ b/NetUtilsTests/NetUtilsTests.swift
@@ -14,23 +14,23 @@ class NetUtilsTests: XCTestCase {
 
     func testNonLoopbackIPV4Interfaces() {
         let interfaces = Interface.allInterfaces()
-        let filtered = interfaces.filter { ($0.getFamily() == .ipv4 && !$0.isLoopback()) }
+        let filtered = interfaces.filter { ($0.family == .ipv4 && !$0.isLoopback) }
         dumpInterfaces(filtered)
         XCTAssertTrue(filtered.count >= 1)
     }
 
     func testCreateDummyInterface() {
         let i = Interface.createTestDummy("dummyInterface", family: .ipv4, address: "1.2.3.4", multicastSupported: false, broadcastAddress: "5.6.7.8")
-        XCTAssertEqual(i.getName(), "dummyInterface")
-        XCTAssertEqual(i.getFamily(), Interface.Family.ipv4)
-        XCTAssertEqual(i.getAddress(), "1.2.3.4")
-        XCTAssertFalse(i.supportsMulticast())
-        XCTAssertEqual(i.getBroadcastAddress(), "5.6.7.8")
+        XCTAssertEqual(i.name, "dummyInterface")
+        XCTAssertEqual(i.family, Interface.Family.ipv4)
+        XCTAssertEqual(i.address, "1.2.3.4")
+        XCTAssertFalse(i.supportsMulticast)
+        XCTAssertEqual(i.broadcastAddress, "5.6.7.8")
     }
     
     func testInet4AddressAsByteArray() {
         let i = Interface.createTestDummy("lo0", family: .ipv4, address: "127.0.0.1", multicastSupported: false, broadcastAddress: nil)
-        let bytes:[UInt8] = i.getAddressBytes()!
+        let bytes:[UInt8] = i.addressBytes!
         XCTAssertEqual(bytes.count, 4)
         XCTAssertEqual(bytes[0], 0x7F)
         XCTAssertEqual(bytes[1], 0)
@@ -40,7 +40,7 @@ class NetUtilsTests: XCTestCase {
     
     func testInet6AddressAsByteArray() {
         let i = Interface.createTestDummy("lo0", family: .ipv6, address: "fe80::dead:beaf", multicastSupported: false, broadcastAddress: nil)
-        let addressbytes:[UInt8]? = i.getAddressBytes()
+        let addressbytes:[UInt8]? = i.addressBytes
         XCTAssert(addressbytes != nil)
         if let bytes = addressbytes {
             XCTAssertEqual(bytes.count, 16)
@@ -65,21 +65,21 @@ class NetUtilsTests: XCTestCase {
 
     func dumpInterfaces(interfaces:[Interface]) {
         for i in interfaces {
-            let running = i.isRunning() ? "running" : "not running"
-            let up = i.isUp() ? "up" : "down"
-            let loopback = i.isLoopback() ? ", loopback" : ""
-            print("\(i.getName()) (\(running), \(up)\(loopback))")
-            print("    Family: \(i.getFamily().toString())")
-            if let a = i.getAddress() {
+            let running = i.isRunning ? "running" : "not running"
+            let up = i.isUp ? "up" : "down"
+            let loopback = i.isLoopback ? ", loopback" : ""
+            print("\(i.name) (\(running), \(up)\(loopback))")
+            print("    Family: \(i.family.toString())")
+            if let a = i.address {
                 print("    Address: \(a)")
             }
-            if let nm = i.getNetmask() {
+            if let nm = i.netmask {
                 print("    Netmask: \(nm)")
             }
-            if let b = i.getBroadcastAddress() {
+            if let b = i.broadcastAddress {
                 print("    broadcast: \(b)")
             }
-            let mc = i.supportsMulticast() ? "yes" : "no"
+            let mc = i.supportsMulticast ? "yes" : "no"
             print("    multicast: \(mc)")
         }
     }


### PR DESCRIPTION
This way the extra parenthesis can be removed when used. The variables are already declared with let therefore they can't be changed.